### PR TITLE
Accept day as input

### DIFF
--- a/lib/spanner.rb
+++ b/lib/spanner.rb
@@ -62,8 +62,8 @@ class Spanner
         # part is context
         multiplier = case part
                      when "s", "sec", "seconds" then 1
-                     when "h", "hours", "hrs" then 3600
                      when "m", "min", "minutes" then 60
+                     when "h", "hours", "hrs" then 3600
                      when "d", "days" then 86_400
                      when "w", "wks", "weeks" then 604_800
                      when "months", "month", "M" then length_of_month

--- a/lib/spanner.rb
+++ b/lib/spanner.rb
@@ -70,7 +70,8 @@ class Spanner
                      when "years", "y" then 31_556_926
                      when /\As/ then 1
                      when /\Am/ then 60
-                     when /\Ah/ then 86_400
+                     when /\Ah/ then 3600
+                     when /\Ad/ then 86_400
                      when /\Aw/ then 604_800
                      when /\AM/ then length_of_month
                      when /\Ay/ then 31_556_926

--- a/test/spanner_test.rb
+++ b/test/spanner_test.rb
@@ -10,7 +10,7 @@ describe Spanner do
   end
 
   #simple
-  { '.5s' => 0.5, '1s' => 1, '1.5s' => 1.5, '1m' => 60, '1.5m' => 90, '1hr' => 3600, '1d' => 86400, '1.7233312d' => 148895.81568, '1M' => Spanner.days_in_month(Time.new.year, Time.new.month) * 24 * 60 * 60 }.each do |input, output|
+  { '.5s' => 0.5, '1s' => 1, '1.5s' => 1.5, '1m' => 60, '1.5m' => 90, '1hr' => 3600, '1d' => 86400, '1 day' => 86400, '1.7233312d' => 148895.81568, '1M' => Spanner.days_in_month(Time.new.year, Time.new.month) * 24 * 60 * 60 }.each do |input, output|
     it "should parse #{input} and return #{output}" do
       assert_equal output, Spanner.parse(input)
     end

--- a/test/spanner_test.rb
+++ b/test/spanner_test.rb
@@ -10,7 +10,7 @@ describe Spanner do
   end
 
   #simple
-  { '.5s' => 0.5, '1s' => 1, '1.5s' => 1.5, '1m' => 60, '1.5m' => 90, '1d' => 86400, '1.7233312d' => 148895.81568, '1M' => Spanner.days_in_month(Time.new.year, Time.new.month) * 24 * 60 * 60 }.each do |input, output|
+  { '.5s' => 0.5, '1s' => 1, '1.5s' => 1.5, '1m' => 60, '1.5m' => 90, '1hr' => 3600, '1d' => 86400, '1.7233312d' => 148895.81568, '1M' => Spanner.days_in_month(Time.new.year, Time.new.month) * 24 * 60 * 60 }.each do |input, output|
     it "should parse #{input} and return #{output}" do
       assert_equal output, Spanner.parse(input)
     end


### PR DESCRIPTION
Hi there!

I noticed a problem when trying to give '1 day' as input to the gem, so I wrote a little patch to fix the problem. I know there's already forks of this gem which add similar functionality, but I had issues getting them to install via bundler, so I thought you'd appreciate this little patch anyway.

The changes in this patch are as follows:
- Fixed parsing of strings starting with "h", so that "1hr" is parsed as 1 hour, not 1 day
- This also fixes parsing of strings starting with "d", so that "1 day" is correctly parsed as 1 day
- Added tests to verify that the above is the case
- Rearrange the ordering of the case statement so that the time values are in ascending order (cosmetic refactor)

If you have any questions, feel free to let me know!